### PR TITLE
💡 Valve-Tweak: prep 0.1.0 pre-release

### DIFF
--- a/.grimoire/src.md
+++ b/.grimoire/src.md
@@ -4,3 +4,4 @@
 |------|---------|------|
 | `src/agentcop.ts` | Valve-Tuner | CLI that enforces AGENTS.md order |
 | `.github/workflows/ci.yml` | Pressure Gauge | Node test pipeline |
+| `CHANGELOG.md` | Timekeeper | Chronology of releases |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-06-14
+### Added
+- Build script to transpile TypeScript into `dist/`.
+- CLI distribution via `npx agentcop`.
+- This CHANGELOG.
+
+## [0.0.0] - 2025-06-14
+### Added
+- Initial linter implementation and tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "agentcop-hubbub",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentcop-hubbub",
-      "version": "0.0.0",
+      "version": "0.1.0",
+      "bin": {
+        "agentcop": "dist/agentcop.js"
+      },
       "devDependencies": {
         "@types/chai": "^4.3.0",
         "@types/mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "agentcop-hubbub",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "scripts": {
+    "build": "tsc",
     "test": "npm run lint && mocha -r ts-node/register \"tests/**/*.ts\"",
     "lint": "ts-node src/agentcop.ts AGENTS.md"
+  },
+  "bin": {
+    "agentcop": "dist/agentcop.js"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/src/agentcop.ts
+++ b/src/agentcop.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env node
 import { readFileSync } from 'fs';
 
 const required = ["Project Map", "Functional Directives", "Style Rules"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- bump version to 0.1.0
- compile TS to `dist/` with new build script
- expose CLI via `bin` entry
- document release history
- chronicle CHANGELOG in the grimoire

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d35601e98832f941ab6fa3fa5f194