### PR TITLE
💡 Valve-Tweak: linter v0.2 deeper rules

### DIFF
--- a/.grimoire/src.md
+++ b/.grimoire/src.md
@@ -5,3 +5,4 @@
 | `src/agentcop.ts` | Valve-Tuner | CLI that enforces AGENTS.md order |
 | `.github/workflows/ci.yml` | Pressure Gauge | Node test pipeline |
 | `CHANGELOG.md` | Timekeeper | Chronology of releases |
+| `src/rules.ts` | Surge-Monitor | Validator helpers for version 0.2 |

--- a/src/agentcop.ts
+++ b/src/agentcop.ts
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
+// Valve-Tuner v0.2
 import { readFileSync } from 'fs';
+import { parseHeadings, hasDuplicateTopLevel, sectionContent } from './rules';
 
-const required = ["Project Map", "Functional Directives", "Style Rules"];
+const required = ['Project Map', 'Functional Directives', 'Style Rules'];
 
 function checkFile(path: string): number {
   const content = readFileSync(path, 'utf8');
   const lines = content.split(/\r?\n/);
+  const headings = parseHeadings(lines);
+
+  const dup = hasDuplicateTopLevel(headings);
+  if (dup) {
+    console.error(`\u26a0\ufe0f Pressure surge: duplicate top-level "${dup}"`);
+    return 1;
+  }
+
   let index = 0;
-  for (const line of lines) {
-    const m = line.match(/^#{1,6}\s*(.*)$/);
-    if (!m) continue;
-    const text = m[1];
-    if (text.includes(required[index])) {
+  for (const h of headings) {
+    if (h.text.includes(required[index])) {
       index++;
       if (index === required.length) break;
     }
@@ -21,6 +28,42 @@ function checkFile(path: string): number {
     console.error(`\u26a0\ufe0f Pressure drop: expected heading "${missing}"`);
     return 1;
   }
+
+  for (const h of headings) {
+    for (const req of required) {
+      if (h.text.includes(req)) {
+        const body = sectionContent(lines, headings, h);
+        if (!body.some((l) => l.trim())) {
+          console.error(`\u26a0\ufe0f Pressure void: section "${req}" empty`);
+          return 1;
+        }
+      }
+    }
+  }
+
+  const funcHeading = headings.find((h) => h.text.includes('Functional Directives'));
+  if (funcHeading) {
+    const body = sectionContent(lines, headings, funcHeading);
+    for (let i = 0; i < body.length; i++) {
+      const open = body[i].match(/^(`{3,})bash\s*$/);
+      if (open) {
+        const fence = open[1];
+        let hasCmd = false;
+        i++;
+        for (; i < body.length; i++) {
+          if (body[i].startsWith(fence)) break;
+          if (body[i].trim()) hasCmd = true;
+        }
+        if (!hasCmd) {
+          console.error(
+            '\u26a0\ufe0f Pressure void: bash block without commands',
+          );
+          return 1;
+        }
+      }
+    }
+  }
+
   return 0;
 }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,0 +1,37 @@
+export interface Heading {
+  text: string;
+  level: number;
+  line: number;
+}
+
+export function parseHeadings(lines: string[]): Heading[] {
+  const headings: Heading[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s*(.*)$/);
+    if (m) {
+      headings.push({ level: m[1].length, text: m[2], line: i });
+    }
+  }
+  return headings;
+}
+
+export function hasDuplicateTopLevel(headings: Heading[]): string | null {
+  const seen = new Set<string>();
+  for (const h of headings) {
+    if (h.level === 1) {
+      if (seen.has(h.text)) return h.text;
+      seen.add(h.text);
+    }
+  }
+  return null;
+}
+
+export function sectionContent(
+  lines: string[],
+  headings: Heading[],
+  heading: Heading,
+): string[] {
+  const start = heading.line + 1;
+  const next = headings.find((h) => h.line > heading.line)?.line ?? lines.length;
+  return lines.slice(start, next);
+}

--- a/tests/agentcop.test.ts
+++ b/tests/agentcop.test.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { expect } from 'chai';
 
 describe('AgentCop', function () {
+  this.timeout(6000);
   const cli = join(__dirname, '..', 'src', 'agentcop.ts');
 
   it('passes with a good AGENTS file', function (done) {
@@ -18,6 +19,33 @@ describe('AgentCop', function () {
     execFile('node', ['-r', 'ts-node/register', cli, file], (error, stdout, stderr) => {
       expect(error).to.be.an('Error');
       expect(stderr).to.contain('Pressure drop');
+      done();
+    });
+  });
+
+  it('fails on duplicate headings', function (done) {
+    const file = join(__dirname, 'fixtures', 'duplicate_headings.md');
+    execFile('node', ['-r', 'ts-node/register', cli, file], (error, stdout, stderr) => {
+      expect(error).to.be.an('Error');
+      expect(stderr).to.contain('duplicate top-level');
+      done();
+    });
+  });
+
+  it('fails on empty section', function (done) {
+    const file = join(__dirname, 'fixtures', 'empty_section.md');
+    execFile('node', ['-r', 'ts-node/register', cli, file], (error, stdout, stderr) => {
+      expect(error).to.be.an('Error');
+      expect(stderr).to.contain('section');
+      done();
+    });
+  });
+
+  it('fails when bash block lacks commands', function (done) {
+    const file = join(__dirname, 'fixtures', 'functional_no_command.md');
+    execFile('node', ['-r', 'ts-node/register', cli, file], (error, stdout, stderr) => {
+      expect(error).to.be.an('Error');
+      expect(stderr).to.contain('bash block');
       done();
     });
   });

--- a/tests/fixtures/duplicate_headings.md
+++ b/tests/fixtures/duplicate_headings.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+# AGENTS.md
+
+## Project Map
+- src/ ➜ Gauge Room
+
+## Functional Directives
+```bash
+npm i
+```
+
+## Style Rules
+Use Prettier.

--- a/tests/fixtures/empty_section.md
+++ b/tests/fixtures/empty_section.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Project Map
+
+## Functional Directives
+```bash
+npm i
+```
+
+## Style Rules
+Use Prettier.

--- a/tests/fixtures/functional_no_command.md
+++ b/tests/fixtures/functional_no_command.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+## Project Map
+- src/ ➜ Gauge Room
+
+## Functional Directives
+```bash
+```
+
+## Style Rules
+Use Prettier.


### PR DESCRIPTION
## Summary
- expand validator with helpers and version banner
- enforce duplicate heading, empty sections, and bash command checks
- document new helper in the grimoire
- add fixtures and tests for rule coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d38054e68832f81a08146a85c0bb7